### PR TITLE
PseudoLogin - Cookie Test

### DIFF
--- a/ComicClient/package-lock.json
+++ b/ComicClient/package-lock.json
@@ -6519,6 +6519,11 @@
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
     },
+    "ngx-cookie-service": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-2.0.0.tgz",
+      "integrity": "sha512-HqKrpdeWSO3ryLe/QTlBBsai9et8Iz9i7PBrvi/fMRmBVEqUbjXp/uIjWDA+K707C2MpVkImyzU0VrvnbS+iFA=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/ComicClient/package.json
+++ b/ComicClient/package.json
@@ -23,6 +23,7 @@
     "core-js": "^2.5.4",
     "foundation-sites": "^6.5.0",
     "jquery": "^3.3.1",
+    "ngx-cookie-service": "^2.0.0",
     "node-sass": "^4.10.0",
     "rxjs": "~6.3.3",
     "zone.js": "~0.8.26"

--- a/ComicClient/src/app/app.component.ts
+++ b/ComicClient/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { pipe } from 'rxjs';
 
 import * as $ from 'jquery';
 import 'foundation-sites';
+import { CookieService } from 'ngx-cookie-service';
 
 @Component({
   selector: 'app-root',
@@ -17,14 +18,13 @@ export class AppComponent {
   // NOTE: Localhost for demo purposes only.
   private apiUrl = 'https://localhost:44350/api/';
   public testData: string;
-
   public ngOnInit() {
     $(document).ready(function() {
       $(document).foundation();
     });
   }
 
-  constructor(private http: Http) {
+  constructor(private http: Http, private cookieService: CookieService) {
     console.log("Initiating API connection test:")
     this.connectionDemo().subscribe(data => { 
       this.setTestData(data["_body"]);
@@ -39,5 +39,12 @@ export class AppComponent {
     console.log(data);
     this.testData = data;
     console.log(this.testData);
+
+    this.setTestCookie(this.testData);
+  }
+
+  setTestCookie(data: any) {
+    this.cookieService.set('CollectAComicTestCookie', data);
+    console.log(this.cookieService.get('CollectAComicTestCookie'));
   }
 }

--- a/ComicClient/src/app/app.module.ts
+++ b/ComicClient/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HttpModule } from '@angular/http';
 
+import { CookieService } from 'ngx-cookie-service';
+
 @NgModule({
   declarations: [
     AppComponent
@@ -14,7 +16,10 @@ import { HttpModule } from '@angular/http';
     AppRoutingModule,
     HttpModule
   ],
-  providers: [AppComponent],
+  providers: [
+    AppComponent,
+    CookieService
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }


### PR DESCRIPTION
Add CookieService package to Angular and test saving/fetching a cookie. This will be used to implement a fake login system for the site and to read/write any other cookies that might be required.